### PR TITLE
style: consistent-type-imports

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,6 +67,7 @@ module.exports = {
         '@typescript-eslint/ban-types': 'off',
         '@typescript-eslint/prefer-as-const': 'off',
         '@typescript-eslint/explicit-module-boundary-types': 'off',
+        '@typescript-eslint/consistent-type-imports': ['error'],
 
         complexity: ['warn', 35], // TODO: set to 25
         'babel/no-invalid-this': 'warn',

--- a/index.js
+++ b/index.js
@@ -67,7 +67,7 @@ module.exports = {
         '@typescript-eslint/ban-types': 'off',
         '@typescript-eslint/prefer-as-const': 'off',
         '@typescript-eslint/explicit-module-boundary-types': 'off',
-        '@typescript-eslint/consistent-type-imports': ['error'],
+        '@typescript-eslint/consistent-type-imports': 'warn',
 
         complexity: ['warn', 35], // TODO: set to 25
         'babel/no-invalid-this': 'warn',


### PR DESCRIPTION
Add @typescript-eslint/consistent-type-imports rule to error level. This
enforces consistent usage of type imports. More here: https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/consistent-type-imports.md