### PR TITLE
turn off no-undef to not flood js files with errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -84,6 +84,7 @@ module.exports = {
         'no-unused-expressions': ['error', { allowShortCircuit: true, allowTernary: true }],
         'no-unused-vars': 'off',
         'no-empty': ['error', { allowEmptyCatch: true }],
+        'no-undef': 'off',
 
         'react/jsx-no-bind': 'off',
         'react/jsx-boolean-value': 'off',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-hometogo",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "ESLint configuration used by HomeToGo",
   "main": "index.js",
   "license": "MIT",


### PR DESCRIPTION
1. Turn off `no-undef` to stop flooding `*.js` files with errors.
(`*.ts` already had this disabled by extending `plugin:@typescript-eslint/eslint-recommended`)

><img width="913" alt="Screenshot 2022-04-07 at 11 44 39" src="https://user-images.githubusercontent.com/44462958/162159588-de17638c-71b8-494a-bac9-f82d12a63cd1.png">
