### PR TITLE
Enable `import/no-duplicates` eslint rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -97,7 +97,6 @@ module.exports = {
         'react/jsx-no-target-blank': 'off',
         'react/jsx-key': 'warn',
 
-        'import/no-duplicates': 'off',
         'import/no-deprecated': 'warn',
         'import/no-extraneous-dependencies': 'warn',
         'import/no-default-export': 'error',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-hometogo",
-  "version": "1.5.3",
+  "version": "1.6.0",
   "description": "ESLint configuration used by HomeToGo",
   "main": "index.js",
   "license": "MIT",


### PR DESCRIPTION
Showcase of how auto-fix works for this rule: https://github.com/hometogo/homeowner-frontend/compare/showcase_no_duplicates_rule?expand=1

It also works correctly with separating type imports (does not report them as duplicate)